### PR TITLE
fix: resolve Docker test hanging issue in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,13 +150,30 @@ jobs:
           push: false
           load: true
       
-      - name: Test Docker image
+      - name: Test Docker image - stdio mode
         run: |
+          # Test basic functionality with stdio mode (default)
           docker run --rm -e STORAGE_TYPE=sqlite mcp-memory-enhanced:test node dist/index.js --version
-          docker run --rm -e TRANSPORT_TYPE=http -e HTTP_PORT=3000 -e PORT=6970 -p 3000:3000 -p 6970:6970 -d --name test-container mcp-memory-enhanced:test
+          
+          # Test that the container can start and respond to health checks in stdio mode
+          docker run --rm -e STORAGE_TYPE=sqlite -e PORT=6970 -p 6970:6970 -d --name test-stdio mcp-memory-enhanced:test
           sleep 5
-          curl -f http://localhost:3000/health || exit 1
-          docker stop test-container
+          curl -f http://localhost:6970/health || exit 1
+          docker stop test-stdio
+      
+      - name: Test Docker image - HTTP mode
+        run: |
+          # Test HTTP transport mode with explicit command to ensure proper startup
+          docker run --rm -e STORAGE_TYPE=sqlite -e TRANSPORT_TYPE=http -e HTTP_PORT=3000 -p 3000:3000 -d --name test-http mcp-memory-enhanced:test node dist/index.js
+          sleep 10
+          # Try health check on HTTP port
+          curl -f http://localhost:3000/health || {
+            echo "Health check failed, checking container logs..."
+            docker logs test-http
+            docker stop test-http || true
+            exit 1
+          }
+          docker stop test-http
 
   security-scan:
     name: Security Scan


### PR DESCRIPTION
## Summary
- Fixed Docker test hanging issue that was causing CI workflow to be cancelled after 10+ minutes
- Split Docker container tests into separate stdio and HTTP mode tests
- Added proper error handling and logging for debugging

## Problem
The CI workflow was hanging during the Docker Build Test job when trying to test the container in HTTP mode. The container was starting in stdio mode instead of HTTP mode, causing the health check to timeout after 10 minutes.

## Solution
1. **Split tests**: Separated stdio and HTTP mode tests for better isolation
2. **Test stdio first**: Verify basic container functionality with default stdio mode
3. **Explicit command for HTTP**: Added explicit `node dist/index.js` command when running HTTP mode test
4. **Better error handling**: Added container log output on failure for debugging
5. **Increased wait time**: Extended sleep to 10 seconds for HTTP mode to ensure proper startup
6. **Cleanup**: Added explicit `docker stop` commands to properly clean up containers

## Testing
- The stdio mode test verifies the container starts correctly with health check on port 6970
- The HTTP mode test explicitly runs the server and checks health on port 3000
- Both tests include proper cleanup to avoid container conflicts

## Impact
This fix will resolve the hanging CI pipeline issue and allow all tests to complete successfully, including the Security Scan job that depends on docker-build-test.