### PR TITLE
fix: handle missing GitHub release in UnRAID template workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -107,9 +107,17 @@ jobs:
           name: unraid-template-${{ github.ref_name }}
           path: unraid-template.xml
       
-      - name: Create release asset
+      - name: Create or update release with UnRAID template
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Check if release exists, create if it doesn't
+          if ! gh release view ${{ github.ref_name }} > /dev/null 2>&1; then
+            echo "Creating release ${{ github.ref_name }}"
+            gh release create ${{ github.ref_name }} \
+              --title "Release ${{ github.ref_name }}" \
+              --notes "Docker image available at: ghcr.io/${{ env.IMAGE_NAME }}:${{ github.ref_name }}"
+          fi
+          # Upload the UnRAID template
           gh release upload ${{ github.ref_name }} unraid-template.xml --clobber


### PR DESCRIPTION
## Summary
- Fixed the UnRAID template workflow that was failing when tags were pushed before releases were created
- Added check to see if release exists before attempting to upload assets
- Automatically creates a release if it doesn't exist

## Problem
The workflow was failing with "release not found" error when a tag was pushed but no corresponding GitHub release existed yet.

## Solution
Modified the workflow to:
1. Check if the release exists using `gh release view`
2. If not, create a basic release with `gh release create`
3. Then upload the UnRAID template to the release

This ensures the workflow succeeds regardless of whether the release was created manually or not.

## Testing
The fix will be validated when the next tag is pushed.