### PR TITLE
chore: add Claude Code config and fix start script

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_response.filePath // .tool_input.file_path' | { read -r f; case \"$f\" in *.ts) [ -x \"$CLAUDE_PROJECT_DIR/node_modules/.bin/eslint\" ] && \"$CLAUDE_PROJECT_DIR/node_modules/.bin/eslint\" --fix \"$f\";; esac; } 2>/dev/null || true",
+            "statusMessage": "Linting edited TypeScript..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: check
+description: Run the local CI gate (lint, type-check, tests) before pushing. Use to verify changes pass the same checks GitHub Actions enforces.
+---
+
+Run the project's CI gate locally — the same steps `.github/workflows/ci.yml` runs. Execute in order and report which pass/fail:
+
+1. `npm run lint`
+2. `npm run typecheck`
+3. `npm test`
+
+If any step fails, stop and show the failing output rather than continuing. If the user is making changes to covered files, optionally run `npm run test:coverage` and confirm coverage stays at/above the CI thresholds (85% lines, 85% functions, 80% branches).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+- Build: `npm run build` (runs `tsc` then `chmod +x dist/*.js`)
+- Type-check only: `npm run typecheck`
+- Lint: `npm run lint` (ESLint flat config in `eslint.config.js`, `eslint . --ext .ts`)
+- Test: `npm test` (Vitest). Single file: `npx vitest run test/unit/health-server.test.ts`. By name: `npx vitest run -t "test name"`. Coverage: `npm run test:coverage`.
+- Run the server: stdio (default) `node dist/index.js`; HTTP/SSE `npm run start:http` / `npm run start:sse`.
+
+## Architecture
+
+`index.ts` is the entry point and routes by `TRANSPORT_TYPE` (stdio default; http/sse dynamically import `http-server.ts`). `KnowledgeGraphManager` (`knowledge-graph-manager.ts`) holds business logic over a pluggable `IStorageBackend` — `storage/json-storage.ts` (JSONL) or `storage/sqlite-storage.ts` (better-sqlite3) — selected by `storage/factory.ts`. MCP tool definitions live in `server-factory.ts` and `server-factory-schemas.ts`.
+
+## Gotchas
+
+- `STORAGE_TYPE` defaults to `json`. Set `STORAGE_TYPE=sqlite` explicitly to use the performance backend.
+- `better-sqlite3` is a native module — local dev needs build tools (Python 3, make, g++); Docker handles this.
+- Three tsconfigs: `tsconfig.json` (build), `tsconfig.eslint.json` (lint), `tsconfig.docker.json` (Docker). Edit the right one for the context.
+
+## Testing & CI
+
+- Vitest runs with `globals: true` — `describe`/`it`/`expect` are available without imports.
+- CI enforces coverage: **85% lines, 85% functions, 80% branches**. When changing covered files (`storage/**`, `knowledge-graph-manager.ts`, `server-factory.ts`, ...), keep coverage at or above threshold or CI fails.
+
+## Repo etiquette
+
+- `main` is protected — PRs only, never commit directly.
+- Branch naming: `feat|fix|chore/VERSION/description` (e.g. `feat/1.0.1/postgres-backend`), based off the current `release/x.x.x` branch. See `BRANCHING.md`.
+- Conventional-commit messages (`feat:`, `fix:`, `chore:`).

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "benchmark:quick": "NODE_OPTIONS='--expose-gc' vitest bench test/benchmarks/quick-performance.bench.ts --run",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js",
     "start:http": "TRANSPORT_TYPE=http npm start",
     "start:sse": "TRANSPORT_TYPE=sse npm start"
   },


### PR DESCRIPTION
## Summary
Sets up Claude Code project configuration and fixes a broken npm script discovered during setup.

- **`CLAUDE.md`** — project commands, architecture overview (pluggable storage backends), gotchas (`STORAGE_TYPE` default, `better-sqlite3` native build, three tsconfigs), Vitest/CI coverage thresholds, and branch/commit etiquette.
- **`.claude/skills/check/SKILL.md`** — `/check` skill that runs the local CI gate (`lint` → `typecheck` → `test`), mirroring `.github/workflows/ci.yml`.
- **`.claude/settings.json`** — `PostToolUse` (Write|Edit) hook running the project's local `eslint --fix` on edited `.ts` files.
- **`package.json`** — adds the missing `"start": "node dist/index.js"` script, fixing `start:http` / `start:sse` (they referenced a nonexistent `npm start`).

## Test plan
- CI lint/typecheck/test must pass.
- `npm run start:http` now boots without the `npm start` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)