### PR TITLE
fix: atomic, durable, serialized JSON storage writes (2/6)

### DIFF
--- a/storage/json-storage.ts
+++ b/storage/json-storage.ts
@@ -10,11 +10,20 @@ import { IStorageBackend, IStorageConfig } from './interface.js';
 export class JSONStorage implements IStorageBackend {
   private filePath: string;
 
+  /**
+   * Serializes mutating operations. Each mutation is a read-modify-write over
+   * the whole file, so concurrent mutations must not interleave or they would
+   * silently overwrite each other's changes. Every public mutator runs inside
+   * this queue; reads are safe to run concurrently because saveGraph() replaces
+   * the file atomically (see saveGraph).
+   */
+  private writeQueue: Promise<unknown> = Promise.resolve();
+
   constructor(config: IStorageConfig) {
     // Use provided file path or default
     const defaultPath = path.join(
-      path.dirname(fileURLToPath(import.meta.url)), 
-      '..', 
+      path.dirname(fileURLToPath(import.meta.url)),
+      '..',
       'memory.json'
     );
 
@@ -23,11 +32,21 @@ export class JSONStorage implements IStorageBackend {
     // Handle relative paths
     if (!path.isAbsolute(this.filePath)) {
       this.filePath = path.join(
-        path.dirname(fileURLToPath(import.meta.url)), 
-        '..', 
+        path.dirname(fileURLToPath(import.meta.url)),
+        '..',
         this.filePath
       );
     }
+  }
+
+  /**
+   * Run a mutating task serialized behind any in-flight mutation. The chain is
+   * kept alive across rejections so one failed mutation does not wedge the queue.
+   */
+  private enqueue<T>(task: () => Promise<T>): Promise<T> {
+    const result = this.writeQueue.then(task, task);
+    this.writeQueue = result.then(() => undefined, () => undefined);
+    return result;
   }
 
   async initialize(): Promise<void> {
@@ -37,27 +56,40 @@ export class JSONStorage implements IStorageBackend {
   }
 
   async loadGraph(): Promise<KnowledgeGraph> {
+    let data: string;
     try {
-      const data = await fs.readFile(this.filePath, "utf-8");
-      const lines = data.split("\n").filter(line => line.trim() !== "");
-      return lines.reduce((graph: KnowledgeGraph, line) => {
-        const item = JSON.parse(line);
-        if (item.type === "entity") {
-          const { type: _type, ...entity } = item;
-          graph.entities.push(entity as Entity);
-        }
-        if (item.type === "relation") {
-          const { type: _type, ...relation } = item;
-          graph.relations.push(relation as Relation);
-        }
-        return graph;
-      }, { entities: [], relations: [] });
+      data = await fs.readFile(this.filePath, "utf-8");
     } catch (error) {
-      if (error instanceof Error && 'code' in error && (error as any).code === "ENOENT") {
+      if (error instanceof Error && 'code' in error && (error as { code?: string }).code === "ENOENT") {
         return { entities: [], relations: [] };
       }
       throw error;
     }
+
+    const graph: KnowledgeGraph = { entities: [], relations: [] };
+    const lines = data.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (line === "") continue;
+
+      let item: { type?: string; [key: string]: unknown };
+      try {
+        item = JSON.parse(line);
+      } catch (error) {
+        throw new Error(
+          `Failed to parse ${this.filePath} at line ${i + 1}: ${(error as Error).message}`
+        );
+      }
+
+      if (item.type === "entity") {
+        const { type: _type, ...entity } = item;
+        graph.entities.push(entity as unknown as Entity);
+      } else if (item.type === "relation") {
+        const { type: _type, ...relation } = item;
+        graph.relations.push(relation as unknown as Relation);
+      }
+    }
+    return graph;
   }
 
   async saveGraph(graph: KnowledgeGraph): Promise<void> {
@@ -65,92 +97,123 @@ export class JSONStorage implements IStorageBackend {
       ...graph.entities.map(e => JSON.stringify({ type: "entity", ...e })),
       ...graph.relations.map(r => JSON.stringify({ type: "relation", ...r })),
     ];
-    await fs.writeFile(this.filePath, lines.join("\n"));
+    const data = lines.join("\n");
+
+    // Write to a temp file, flush it to disk, then atomically rename over the
+    // target. A crash at any point leaves either the previous complete file or
+    // the new complete file - never a half-written/corrupt one.
+    const tmpPath = `${this.filePath}.${process.pid}.tmp`;
+    const handle = await fs.open(tmpPath, "w");
+    try {
+      await handle.writeFile(data, "utf-8");
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    try {
+      await fs.rename(tmpPath, this.filePath);
+    } catch (error) {
+      // Best-effort cleanup of the temp file if the rename failed.
+      await fs.rm(tmpPath, { force: true }).catch(() => undefined);
+      throw error;
+    }
   }
 
   async createEntities(entities: Entity[]): Promise<Entity[]> {
-    const graph = await this.loadGraph();
-    const newEntities = entities.filter(
-      e => !graph.entities.some(existingEntity => existingEntity.name === e.name)
-    );
-    graph.entities.push(...newEntities);
-    await this.saveGraph(graph);
-    return newEntities;
+    return this.enqueue(async () => {
+      const graph = await this.loadGraph();
+      const newEntities = entities.filter(
+        e => !graph.entities.some(existingEntity => existingEntity.name === e.name)
+      );
+      graph.entities.push(...newEntities);
+      await this.saveGraph(graph);
+      return newEntities;
+    });
   }
 
   async createRelations(relations: Relation[]): Promise<Relation[]> {
-    const graph = await this.loadGraph();
-    const newRelations = relations.filter(
-      r => !graph.relations.some(existingRelation => 
-        existingRelation.from === r.from && 
-        existingRelation.to === r.to && 
-        existingRelation.relationType === r.relationType
-      )
-    );
-    graph.relations.push(...newRelations);
-    await this.saveGraph(graph);
-    return newRelations;
+    return this.enqueue(async () => {
+      const graph = await this.loadGraph();
+      const newRelations = relations.filter(
+        r => !graph.relations.some(existingRelation =>
+          existingRelation.from === r.from &&
+          existingRelation.to === r.to &&
+          existingRelation.relationType === r.relationType
+        )
+      );
+      graph.relations.push(...newRelations);
+      await this.saveGraph(graph);
+      return newRelations;
+    });
   }
 
   async addObservations(
     observations: { entityName: string; contents: string[] }[]
   ): Promise<{ entityName: string; addedObservations: string[] }[]> {
-    const graph = await this.loadGraph();
-    const results = observations.map(o => {
-      const entity = graph.entities.find(e => e.name === o.entityName);
-      if (!entity) {
-        throw new Error(`Entity with name ${o.entityName} not found`);
-      }
-      const newObservations = o.contents.filter(
-        content => !entity.observations.includes(content)
-      );
-      entity.observations.push(...newObservations);
-      return { entityName: o.entityName, addedObservations: newObservations };
+    return this.enqueue(async () => {
+      const graph = await this.loadGraph();
+      const results = observations.map(o => {
+        const entity = graph.entities.find(e => e.name === o.entityName);
+        if (!entity) {
+          throw new Error(`Entity with name ${o.entityName} not found`);
+        }
+        const newObservations = o.contents.filter(
+          content => !entity.observations.includes(content)
+        );
+        entity.observations.push(...newObservations);
+        return { entityName: o.entityName, addedObservations: newObservations };
+      });
+      await this.saveGraph(graph);
+      return results;
     });
-    await this.saveGraph(graph);
-    return results;
   }
 
   async deleteEntities(entityNames: string[]): Promise<void> {
-    const graph = await this.loadGraph();
-    graph.entities = graph.entities.filter(e => !entityNames.includes(e.name));
-    graph.relations = graph.relations.filter(
-      r => !entityNames.includes(r.from) && !entityNames.includes(r.to)
-    );
-    await this.saveGraph(graph);
+    return this.enqueue(async () => {
+      const graph = await this.loadGraph();
+      graph.entities = graph.entities.filter(e => !entityNames.includes(e.name));
+      graph.relations = graph.relations.filter(
+        r => !entityNames.includes(r.from) && !entityNames.includes(r.to)
+      );
+      await this.saveGraph(graph);
+    });
   }
 
   async deleteObservations(
     deletions: { entityName: string; observations: string[] }[]
   ): Promise<void> {
-    const graph = await this.loadGraph();
-    deletions.forEach(d => {
-      const entity = graph.entities.find(e => e.name === d.entityName);
-      if (entity) {
-        entity.observations = entity.observations.filter(
-          o => !d.observations.includes(o)
-        );
-      }
+    return this.enqueue(async () => {
+      const graph = await this.loadGraph();
+      deletions.forEach(d => {
+        const entity = graph.entities.find(e => e.name === d.entityName);
+        if (entity) {
+          entity.observations = entity.observations.filter(
+            o => !d.observations.includes(o)
+          );
+        }
+      });
+      await this.saveGraph(graph);
     });
-    await this.saveGraph(graph);
   }
 
   async deleteRelations(relations: Relation[]): Promise<void> {
-    const graph = await this.loadGraph();
-    graph.relations = graph.relations.filter(
-      r => !relations.some(delRelation => 
-        r.from === delRelation.from && 
-        r.to === delRelation.to && 
-        r.relationType === delRelation.relationType
-      )
-    );
-    await this.saveGraph(graph);
+    return this.enqueue(async () => {
+      const graph = await this.loadGraph();
+      graph.relations = graph.relations.filter(
+        r => !relations.some(delRelation =>
+          r.from === delRelation.from &&
+          r.to === delRelation.to &&
+          r.relationType === delRelation.relationType
+        )
+      );
+      await this.saveGraph(graph);
+    });
   }
 
   async searchEntities(query: string): Promise<Entity[]> {
     const graph = await this.loadGraph();
     const lowerQuery = query.toLowerCase();
-    return graph.entities.filter(e => 
+    return graph.entities.filter(e =>
       e.name.toLowerCase().includes(lowerQuery) ||
       e.entityType.toLowerCase().includes(lowerQuery) ||
       e.observations.some(o => o.toLowerCase().includes(lowerQuery))
@@ -185,7 +248,7 @@ export class JSONStorage implements IStorageBackend {
   }> {
     const graph = await this.loadGraph();
     const observationCount = graph.entities.reduce(
-      (count, entity) => count + entity.observations.length, 
+      (count, entity) => count + entity.observations.length,
       0
     );
 

--- a/test/unit/storage/json-durability.test.ts
+++ b/test/unit/storage/json-durability.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { JSONStorage } from '../../../storage/json-storage.js';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { tmpdir } from 'os';
+
+/**
+ * Durability/atomicity guarantees specific to the JSON backend:
+ * - mutations are serialized so concurrent read-modify-write cannot lose data
+ * - saveGraph replaces the file atomically (temp + fsync + rename), so reads
+ *   never observe a partially written file and no temp files are left behind
+ * - loadGraph reports the offending line when the file is corrupt
+ */
+describe('JSONStorage durability', () => {
+  let testDir: string;
+  let filePath: string;
+  let storage: JSONStorage;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(tmpdir(), 'mcp-json-durability-'));
+    filePath = path.join(testDir, 'memory.jsonl');
+    storage = new JSONStorage({ type: 'json', filePath });
+    await storage.initialize();
+  });
+
+  afterEach(async () => {
+    await storage.close();
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('serializes concurrent createEntities without losing writes', async () => {
+    const count = 50;
+    await Promise.all(
+      Array.from({ length: count }, (_, i) =>
+        storage.createEntities([{ name: `E${i}`, entityType: 'T', observations: [] }])
+      )
+    );
+
+    const graph = await storage.loadGraph();
+    expect(graph.entities).toHaveLength(count);
+    expect(new Set(graph.entities.map(e => e.name)).size).toBe(count);
+  });
+
+  it('serializes concurrent addObservations to the same entity', async () => {
+    await storage.createEntities([{ name: 'Hub', entityType: 'T', observations: [] }]);
+
+    const count = 40;
+    await Promise.all(
+      Array.from({ length: count }, (_, i) =>
+        storage.addObservations([{ entityName: 'Hub', contents: [`obs-${i}`] }])
+      )
+    );
+
+    const [entity] = await storage.getEntities(['Hub']);
+    expect(entity.observations).toHaveLength(count);
+  });
+
+  it('leaves no temp files behind after writes', async () => {
+    await storage.createEntities([{ name: 'A', entityType: 'T', observations: ['x'] }]);
+    await storage.createEntities([{ name: 'B', entityType: 'T', observations: ['y'] }]);
+
+    const files = await fs.readdir(testDir);
+    expect(files).toEqual(['memory.jsonl']);
+  });
+
+  it('never exposes a partially written file to concurrent readers', async () => {
+    await storage.createEntities([{ name: 'Seed', entityType: 'T', observations: [] }]);
+
+    const write = storage.createEntities(
+      Array.from({ length: 200 }, (_, i) => ({
+        name: `N${i}`,
+        entityType: 'T',
+        observations: ['z'],
+      }))
+    );
+
+    // Interleave reads with the in-flight write; an atomic replace means each
+    // read returns either the old or new complete graph, never throws on a
+    // half-written file.
+    for (let i = 0; i < 20; i++) {
+      const graph = await storage.loadGraph();
+      expect(Array.isArray(graph.entities)).toBe(true);
+    }
+
+    await write;
+    expect((await storage.loadGraph()).entities).toHaveLength(201);
+  });
+
+  it('reports the offending line number when the file is corrupt', async () => {
+    const good = JSON.stringify({
+      type: 'entity',
+      name: 'A',
+      entityType: 'T',
+      observations: [],
+    });
+    await fs.writeFile(filePath, `${good}\n{ this is not valid json`);
+
+    await expect(storage.loadGraph()).rejects.toThrow(/line 2/);
+  });
+});


### PR DESCRIPTION
## Description
Part **2/6** of the v2.0.0 remediation stack (based on #33).

The JSON backend is the default. Previously every mutation was an unserialized load-modify-save and `saveGraph` used a plain `fs.writeFile`.

- `saveGraph` writes to a temp file, `fsync`s it, then **atomically renames** over the target
- All mutators run through a promise-chain **write queue** so concurrent calls can't interleave and lose data
- `loadGraph` reports the **offending line number** on corrupt input
- Added durability tests (concurrent writes, atomicity, line-numbered errors)

## Server Details
- Server: memory
- Changes to: storage backend (JSON)

## Motivation and Context
Concurrent tool calls could silently lose writes, and a crash mid-write could leave a corrupt, unparseable JSONL file.

## How Has This Been Tested?
New `test/unit/storage/json-durability.test.ts` (5 tests) plus the full suite; lint/typecheck green.

## Breaking Changes
None (file format unchanged).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling

## Additional context
Stacked on #33 — merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)