### PR TITLE
perf: eliminate SQLite N+1 observation queries (3/6)

### DIFF
--- a/storage/sqlite-storage.ts
+++ b/storage/sqlite-storage.ts
@@ -88,6 +88,41 @@ export class SQLiteStorage implements IStorageBackend {
     `);
   }
 
+  /**
+   * Load observations grouped by entity id in a single query, avoiding an
+   * N+1 query per entity. When entityIds is omitted, every observation is
+   * loaded (used by loadGraph) - this deliberately avoids an `IN (...)`
+   * clause so it never hits SQLite's bound-parameter limit on large graphs.
+   */
+  private groupObservations(entityIds?: number[]): Map<number, string[]> {
+    let rows: Array<{ entity_id: number; content: string }>;
+    if (entityIds === undefined) {
+      rows = this.db.prepare(`
+        SELECT entity_id, content FROM observations
+        ORDER BY entity_id, created_at, id
+      `).all() as Array<{ entity_id: number; content: string }>;
+    } else {
+      if (entityIds.length === 0) return new Map();
+      const placeholders = entityIds.map(() => '?').join(',');
+      rows = this.db.prepare(`
+        SELECT entity_id, content FROM observations
+        WHERE entity_id IN (${placeholders})
+        ORDER BY entity_id, created_at, id
+      `).all(...entityIds) as Array<{ entity_id: number; content: string }>;
+    }
+
+    const byEntity = new Map<number, string[]>();
+    for (const row of rows) {
+      const list = byEntity.get(row.entity_id);
+      if (list) {
+        list.push(row.content);
+      } else {
+        byEntity.set(row.entity_id, [row.content]);
+      }
+    }
+    return byEntity;
+  }
+
   async loadGraph(): Promise<KnowledgeGraph> {
     // Load all entities with their observations
     const entities = this.db.prepare(`
@@ -96,16 +131,13 @@ export class SQLiteStorage implements IStorageBackend {
       ORDER BY e.name
     `).all() as Array<{ id: number; name: string; entity_type: string }>;
 
-    // Load observations for each entity
-    const getObservations = this.db.prepare(`
-      SELECT content FROM observations WHERE entity_id = ? ORDER BY created_at
-    `);
+    // Load all observations in one query and group by entity (avoids N+1).
+    const observationsByEntity = this.groupObservations();
 
     const entitiesWithObservations: Entity[] = entities.map(entity => ({
       name: entity.name,
       entityType: entity.entity_type,
-      observations: (getObservations.all(entity.id) as Array<{ content: string }>)
-        .map(obs => obs.content)
+      observations: observationsByEntity.get(entity.id) ?? []
     }));
 
     // Load all relations
@@ -338,16 +370,13 @@ export class SQLiteStorage implements IStorageBackend {
       entity_type: string;
     }>;
 
-    // Get observations for each entity
-    const getObservations = this.db.prepare(`
-      SELECT content FROM observations WHERE entity_id = ? ORDER BY created_at
-    `);
+    // Group observations for the matched entities in one query (avoids N+1).
+    const observationsByEntity = this.groupObservations(searchResults.map(e => e.id));
 
     return searchResults.map(entity => ({
       name: entity.name,
       entityType: entity.entity_type,
-      observations: (getObservations.all(entity.id) as Array<{ content: string }>)
-        .map(obs => obs.content)
+      observations: observationsByEntity.get(entity.id) ?? []
     }));
   }
 
@@ -362,15 +391,12 @@ export class SQLiteStorage implements IStorageBackend {
       ORDER BY name
     `).all(...names) as Array<{ id: number; name: string; entity_type: string }>;
 
-    const getObservations = this.db.prepare(`
-      SELECT content FROM observations WHERE entity_id = ? ORDER BY created_at
-    `);
+    const observationsByEntity = this.groupObservations(entities.map(e => e.id));
 
     return entities.map(entity => ({
       name: entity.name,
       entityType: entity.entity_type,
-      observations: (getObservations.all(entity.id) as Array<{ content: string }>)
-        .map(obs => obs.content)
+      observations: observationsByEntity.get(entity.id) ?? []
     }));
   }
 

--- a/test/unit/storage/sqlite-specific.test.ts
+++ b/test/unit/storage/sqlite-specific.test.ts
@@ -132,6 +132,41 @@ describe('SQLite-Specific Features', () => {
       expect(results).toHaveLength(20); // 1000 / 50
       expect(duration).toBeLessThan(100); // Should be very fast due to indexes
     });
+
+    it('loads observations with a constant number of queries (no N+1)', async () => {
+      const entities: Entity[] = Array.from({ length: 25 }, (_, i) => ({
+        name: `NPlus1 ${i}`,
+        entityType: 'Test',
+        observations: [`a-${i}`, `b-${i}`, `c-${i}`]
+      }));
+      await storage.createEntities(entities);
+
+      // Instrument every prepared statement's .all() executions during loadGraph.
+      // The old N+1 implementation ran one observation query per entity
+      // (~N executions); the grouped query keeps this a small constant.
+      const db = (storage as unknown as { db: { prepare: (sql: string) => { all: (...a: unknown[]) => unknown } } }).db;
+      const originalPrepare = db.prepare.bind(db);
+      let allCalls = 0;
+      db.prepare = (sql: string) => {
+        const stmt = originalPrepare(sql);
+        const originalAll = stmt.all.bind(stmt);
+        stmt.all = (...args: unknown[]) => {
+          allCalls++;
+          return originalAll(...args);
+        };
+        return stmt;
+      };
+
+      try {
+        const graph = await storage.loadGraph();
+        expect(graph.entities).toHaveLength(25);
+        expect(graph.entities.every(e => e.observations.length === 3)).toBe(true);
+        // entities + grouped observations + relations = 3, independent of N
+        expect(allCalls).toBeLessThanOrEqual(3);
+      } finally {
+        db.prepare = originalPrepare;
+      }
+    });
   });
 
   describe('WAL Mode', () => {


### PR DESCRIPTION
## Description
Part **3/6** of the v2.0.0 remediation stack.

`loadGraph`, `searchEntities`, and `getEntities` each ran one observation query **per entity**. Replaced with a single grouped query bucketed by entity id in memory. `loadGraph` deliberately loads all observations without an `IN (...)` clause so it never hits SQLite's bound-parameter limit on the large (100K–500K) graphs this project targets.

## Server Details
- Server: memory
- Changes to: storage backend (SQLite)

## Motivation and Context
The N+1 pattern undermined the project's core scalability claim.

## How Has This Been Tested?
Added a regression test asserting `loadGraph` executes a constant number of queries regardless of entity count; full suite + lint/typecheck green.

## Breaking Changes
None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] New and existing tests pass locally

## Additional context
Stacked on #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)