### PR TITLE
fix!: unify tool registration across transports + single-source version (4/6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### ⚠️ Breaking Changes
+- **Tool names are now namespaced with the `memory__` prefix on every transport.**
+  The stdio transport previously exposed unprefixed names (`create_entities`,
+  `read_graph`, ...); it now matches the HTTP/SSE transport (`memory__create_entities`,
+  `memory__read_graph`, ...). MCP clients that discover tools dynamically are
+  unaffected; any client, script, or allow-list that hard-codes the old stdio names
+  must be updated.
+
+### Added
+- `memory__get_stats` is now exposed over HTTP/SSE as well (previously stdio-only), so
+  both transports expose the same 10 tools
+- Shared tool module (`tools.ts`) used by both transports, removing duplicated tool
+  definitions and dispatch logic that could drift between transports
+- JSON-storage durability tests and a SQLite N+1 regression test
+- `.dockerignore`
+
+### Changed
+- The server version reported to MCP clients is now read from `package.json` (single
+  source of truth) instead of a hard-coded string that had drifted to `0.6.3`
+- Coverage thresholds aligned to 85% lines / 85% functions / 80% branches across
+  vitest, CI, and docs
+
+### Fixed
+- **JSON storage durability** - writes are now atomic (temp file + fsync + rename) and
+  serialized, so concurrent tool calls can no longer lose data and a crash mid-write
+  can no longer corrupt the JSONL file; parse errors now report the offending line
+- Resolved unresolved git merge-conflict markers shipped in `README.md`
+- Build now cleans `dist/` first, so stale/test artifacts are no longer published
+
+### Performance
+- Eliminated the SQLite N+1 observation query in `loadGraph`, `searchEntities`, and
+  `getEntities` (one grouped query instead of one query per entity)
+
+### Removed
+- Dead `src/memory/**` tree (excluded from the build, never imported) and stray root
+  files (`test-benchmark.ts`, `test-sqlite.ts`, `test-coverage-analysis.md`)
+
 ## [1.0.3] - 2026-06-13
 
 ### 📊 Benchmarking & Tooling

--- a/index.ts
+++ b/index.ts
@@ -8,8 +8,9 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { KnowledgeGraphManager } from './knowledge-graph-manager.js';
 import { createStorageFromEnv } from './storage/factory.js';
-import { Entity, Relation } from './types.js';
 import { startHealthServer } from './health-server.js';
+import { memoryTools, callMemoryTool } from './tools.js';
+import { VERSION } from './version.js';
 
 // Initialize storage backend and knowledge graph manager
 let knowledgeGraphManager: KnowledgeGraphManager;
@@ -18,246 +19,34 @@ async function initializeStorage() {
   const storage = createStorageFromEnv();
   await storage.initialize();
   knowledgeGraphManager = new KnowledgeGraphManager(storage);
-  
+
   // Log storage type for debugging
   const storageType = process.env.STORAGE_TYPE || 'json';
   console.error(`Using ${storageType} storage backend`);
 }
 
-
-// The server instance and tools exposed to Claude
+// The server instance and tools exposed to Claude. Tool definitions and the
+// dispatch logic are shared with the HTTP/SSE transport via ./tools.ts.
 const server = new Server({
-  name: "memory-server",
-  version: "0.6.3",
-},    {
-    capabilities: {
-      tools: {},
-    },
-  },);
+  name: "memory",
+  version: VERSION,
+}, {
+  capabilities: {
+    tools: {},
+  },
+});
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return {
-    tools: [
-      {
-        name: "create_entities",
-        description: "Create multiple new entities in the knowledge graph",
-        inputSchema: {
-          type: "object",
-          properties: {
-            entities: {
-              type: "array",
-              items: {
-                type: "object",
-                properties: {
-                  name: { type: "string", description: "The name of the entity" },
-                  entityType: { type: "string", description: "The type of the entity" },
-                  observations: { 
-                    type: "array", 
-                    items: { type: "string" },
-                    description: "An array of observation contents associated with the entity"
-                  },
-                },
-                required: ["name", "entityType", "observations"],
-              },
-            },
-          },
-          required: ["entities"],
-        },
-      },
-      {
-        name: "create_relations",
-        description: "Create multiple new relations between entities in the knowledge graph. Relations should be in active voice",
-        inputSchema: {
-          type: "object",
-          properties: {
-            relations: {
-              type: "array",
-              items: {
-                type: "object",
-                properties: {
-                  from: { type: "string", description: "The name of the entity where the relation starts" },
-                  to: { type: "string", description: "The name of the entity where the relation ends" },
-                  relationType: { type: "string", description: "The type of the relation" },
-                },
-                required: ["from", "to", "relationType"],
-              },
-            },
-          },
-          required: ["relations"],
-        },
-      },
-      {
-        name: "add_observations",
-        description: "Add new observations to existing entities in the knowledge graph",
-        inputSchema: {
-          type: "object",
-          properties: {
-            observations: {
-              type: "array",
-              items: {
-                type: "object",
-                properties: {
-                  entityName: { type: "string", description: "The name of the entity to add the observations to" },
-                  contents: { 
-                    type: "array", 
-                    items: { type: "string" },
-                    description: "An array of observation contents to add"
-                  },
-                },
-                required: ["entityName", "contents"],
-              },
-            },
-          },
-          required: ["observations"],
-        },
-      },
-      {
-        name: "delete_entities",
-        description: "Delete multiple entities and their associated relations from the knowledge graph",
-        inputSchema: {
-          type: "object",
-          properties: {
-            entityNames: { 
-              type: "array", 
-              items: { type: "string" },
-              description: "An array of entity names to delete" 
-            },
-          },
-          required: ["entityNames"],
-        },
-      },
-      {
-        name: "delete_observations",
-        description: "Delete specific observations from entities in the knowledge graph",
-        inputSchema: {
-          type: "object",
-          properties: {
-            deletions: {
-              type: "array",
-              items: {
-                type: "object",
-                properties: {
-                  entityName: { type: "string", description: "The name of the entity containing the observations" },
-                  observations: { 
-                    type: "array", 
-                    items: { type: "string" },
-                    description: "An array of observations to delete"
-                  },
-                },
-                required: ["entityName", "observations"],
-              },
-            },
-          },
-          required: ["deletions"],
-        },
-      },
-      {
-        name: "delete_relations",
-        description: "Delete multiple relations from the knowledge graph",
-        inputSchema: {
-          type: "object",
-          properties: {
-            relations: { 
-              type: "array", 
-              items: {
-                type: "object",
-                properties: {
-                  from: { type: "string", description: "The name of the entity where the relation starts" },
-                  to: { type: "string", description: "The name of the entity where the relation ends" },
-                  relationType: { type: "string", description: "The type of the relation" },
-                },
-                required: ["from", "to", "relationType"],
-              },
-              description: "An array of relations to delete" 
-            },
-          },
-          required: ["relations"],
-        },
-      },
-      {
-        name: "read_graph",
-        description: "Read the entire knowledge graph",
-        inputSchema: {
-          type: "object",
-          properties: {},
-        },
-      },
-      {
-        name: "search_nodes",
-        description: "Search for nodes in the knowledge graph based on a query",
-        inputSchema: {
-          type: "object",
-          properties: {
-            query: { type: "string", description: "The search query to match against entity names, types, and observation content" },
-          },
-          required: ["query"],
-        },
-      },
-      {
-        name: "open_nodes",
-        description: "Open specific nodes in the knowledge graph by their names",
-        inputSchema: {
-          type: "object",
-          properties: {
-            names: {
-              type: "array",
-              items: { type: "string" },
-              description: "An array of entity names to retrieve",
-            },
-          },
-          required: ["names"],
-        },
-      },
-      {
-        name: "get_stats",
-        description: "Get statistics about the knowledge graph storage",
-        inputSchema: {
-          type: "object",
-          properties: {},
-        },
-      },
-    ],
-  };
+  return { tools: memoryTools };
 });
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
-
-  if (name === "read_graph") {
-    return { content: [{ type: "text", text: JSON.stringify(await knowledgeGraphManager.readGraph(), null, 2) }] };
-  }
-
-  if (name === "get_stats") {
-    return { content: [{ type: "text", text: JSON.stringify(await knowledgeGraphManager.getStats(), null, 2) }] };
-  }
-
-  if (!args) {
-    throw new Error(`No arguments provided for tool: ${name}`);
-  }
-
-  switch (name) {
-    case "create_entities":
-      return { content: [{ type: "text", text: JSON.stringify(await knowledgeGraphManager.createEntities(args.entities as Entity[]), null, 2) }] };
-    case "create_relations":
-      return { content: [{ type: "text", text: JSON.stringify(await knowledgeGraphManager.createRelations(args.relations as Relation[]), null, 2) }] };
-    case "add_observations":
-      return { content: [{ type: "text", text: JSON.stringify(await knowledgeGraphManager.addObservations(args.observations as { entityName: string; contents: string[] }[]), null, 2) }] };
-    case "delete_entities":
-      await knowledgeGraphManager.deleteEntities(args.entityNames as string[]);
-      return { content: [{ type: "text", text: "Entities deleted successfully" }] };
-    case "delete_observations":
-      await knowledgeGraphManager.deleteObservations(args.deletions as { entityName: string; observations: string[] }[]);
-      return { content: [{ type: "text", text: "Observations deleted successfully" }] };
-    case "delete_relations":
-      await knowledgeGraphManager.deleteRelations(args.relations as Relation[]);
-      return { content: [{ type: "text", text: "Relations deleted successfully" }] };
-    case "search_nodes":
-      return { content: [{ type: "text", text: JSON.stringify(await knowledgeGraphManager.searchNodes(args.query as string), null, 2) }] };
-    case "open_nodes":
-      return { content: [{ type: "text", text: JSON.stringify(await knowledgeGraphManager.openNodes(args.names as string[]), null, 2) }] };
-    default:
-      throw new Error(`Unknown tool: ${name}`);
-  }
+  return callMemoryTool(
+    knowledgeGraphManager,
+    name,
+    args as Record<string, unknown> | undefined
+  );
 });
 
 async function main() {
@@ -269,16 +58,16 @@ async function main() {
     runHttpServer();
     return;
   }
-  
+
   // Initialize storage before starting server
   await initializeStorage();
-  
+
   // Start health check server if port is specified
   const healthPort = parseInt(process.env.PORT || '6970', 10);
   if (!isNaN(healthPort) && healthPort > 0) {
     startHealthServer(healthPort, knowledgeGraphManager);
   }
-  
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error("Knowledge Graph MCP Server running on stdio");

--- a/server-factory-schemas.ts
+++ b/server-factory-schemas.ts
@@ -183,3 +183,8 @@ export const OpenNodesSchema = {
   },
   required: ["names"]
 };
+
+export const GetStatsSchema = {
+  type: "object",
+  properties: {}
+};

--- a/server-factory.ts
+++ b/server-factory.ts
@@ -2,32 +2,22 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { KnowledgeGraphManager } from './knowledge-graph-manager.js';
 import { createStorageFromEnv } from './storage/factory.js';
 import type { IStorageBackend } from './storage/interface.js';
-import { Entity, Relation } from './types.js';
 import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { 
-  CreateEntitiesSchema,
-  CreateRelationsSchema,
-  AddObservationsSchema,
-  DeleteEntitiesSchema,
-  DeleteObservationsSchema,
-  DeleteRelationsSchema,
-  ReadGraphSchema,
-  SearchNodesSchema,
-  OpenNodesSchema,
-} from './server-factory-schemas.js';
+import { memoryTools, callMemoryTool } from './tools.js';
+import { VERSION } from './version.js';
 
 export async function createServerFromFactory(): Promise<Server> {
   const storage: IStorageBackend = createStorageFromEnv();
   await storage.initialize();
   const manager = new KnowledgeGraphManager(storage);
-  
+
   const server = new Server(
     {
       name: 'memory',
-      version: '0.6.3',
+      version: VERSION,
     },
     {
       capabilities: {
@@ -36,98 +26,16 @@ export async function createServerFromFactory(): Promise<Server> {
     }
   );
 
-  // Memory Management Tools
+  // Tool definitions and dispatch are shared with the stdio transport via
+  // ./tools.ts so the two transports can never drift.
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    return {
-      tools: [
-        {
-          name: 'memory__create_entities',
-          description: 'Create multiple new entities in the knowledge graph',
-          inputSchema: CreateEntitiesSchema,
-        },
-        {
-          name: 'memory__create_relations',
-          description: 'Create multiple new relations between entities in the knowledge graph. Relations should be in active voice',
-          inputSchema: CreateRelationsSchema,
-        },
-        {
-          name: 'memory__add_observations',
-          description: 'Add new observations to existing entities in the knowledge graph',
-          inputSchema: AddObservationsSchema,
-        },
-        {
-          name: 'memory__delete_entities',
-          description: 'Delete multiple entities and their associated relations from the knowledge graph',
-          inputSchema: DeleteEntitiesSchema,
-        },
-        {
-          name: 'memory__delete_observations',
-          description: 'Delete specific observations from entities in the knowledge graph',
-          inputSchema: DeleteObservationsSchema,
-        },
-        {
-          name: 'memory__delete_relations',
-          description: 'Delete multiple relations from the knowledge graph',
-          inputSchema: DeleteRelationsSchema,
-        },
-        {
-          name: 'memory__read_graph',
-          description: 'Read the entire knowledge graph',
-          inputSchema: ReadGraphSchema,
-        },
-        {
-          name: 'memory__search_nodes',
-          description: 'Search for nodes in the knowledge graph based on a query',
-          inputSchema: SearchNodesSchema,
-        },
-        {
-          name: 'memory__open_nodes',
-          description: 'Open specific nodes in the knowledge graph by their names',
-          inputSchema: OpenNodesSchema,
-        },
-      ],
-    };
+    return { tools: memoryTools };
   });
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      const { name, arguments: args } = request.params;
-      
-      if (!args) {
-        throw new Error(`No arguments provided for tool: ${name}`);
-      }
-      
-      switch (name) {
-        case 'memory__create_entities':
-          return { content: [{ type: 'text', text: JSON.stringify(await manager.createEntities(args.entities as Entity[])) }] };
-        
-        case 'memory__create_relations':
-          return { content: [{ type: 'text', text: JSON.stringify(await manager.createRelations(args.relations as Relation[])) }] };
-        
-        case 'memory__add_observations':
-          return { content: [{ type: 'text', text: JSON.stringify(await manager.addObservations(args.observations as { entityName: string; contents: string[] }[])) }] };
-        
-        case 'memory__delete_entities':
-          return { content: [{ type: 'text', text: JSON.stringify(await manager.deleteEntities(args.entityNames as string[])) }] };
-        
-        case 'memory__delete_observations':
-          return { content: [{ type: 'text', text: JSON.stringify(await manager.deleteObservations(args.deletions as { entityName: string; observations: string[] }[])) }] };
-        
-        case 'memory__delete_relations':
-          return { content: [{ type: 'text', text: JSON.stringify(await manager.deleteRelations(args.relations as Relation[])) }] };
-        
-        case 'memory__read_graph':
-          return { content: [{ type: 'text', text: JSON.stringify(await manager.readGraph()) }] };
-        
-        case 'memory__search_nodes':
-          return { content: [{ type: 'text', text: JSON.stringify(await manager.searchNodes(args.query as string)) }] };
-        
-        case 'memory__open_nodes':
-          return { content: [{ type: 'text', text: JSON.stringify(await manager.openNodes(args.names as string[])) }] };
-        
-        default:
-          throw new Error(`Unknown tool: ${name}`);
-      }
-    });
+    const { name, arguments: args } = request.params;
+    return callMemoryTool(manager, name, args as Record<string, unknown> | undefined);
+  });
 
   return server;
 }

--- a/test/integration/mcp-server.test.ts
+++ b/test/integration/mcp-server.test.ts
@@ -97,22 +97,22 @@ describe('MCP Server Integration Tests', () => {
           expect(tools.tools).toHaveLength(10);
           
           const toolNames = tools.tools.map(t => t.name);
-          expect(toolNames).toContain('create_entities');
-          expect(toolNames).toContain('create_relations');
-          expect(toolNames).toContain('add_observations');
-          expect(toolNames).toContain('delete_entities');
-          expect(toolNames).toContain('delete_observations');
-          expect(toolNames).toContain('delete_relations');
-          expect(toolNames).toContain('read_graph');
-          expect(toolNames).toContain('search_nodes');
-          expect(toolNames).toContain('open_nodes');
-          expect(toolNames).toContain('get_stats');
+          expect(toolNames).toContain('memory__create_entities');
+          expect(toolNames).toContain('memory__create_relations');
+          expect(toolNames).toContain('memory__add_observations');
+          expect(toolNames).toContain('memory__delete_entities');
+          expect(toolNames).toContain('memory__delete_observations');
+          expect(toolNames).toContain('memory__delete_relations');
+          expect(toolNames).toContain('memory__read_graph');
+          expect(toolNames).toContain('memory__search_nodes');
+          expect(toolNames).toContain('memory__open_nodes');
+          expect(toolNames).toContain('memory__get_stats');
         });
 
         it('should provide correct input schemas for tools', async () => {
           const tools = await client.listTools();
           
-          const createEntities = tools.tools.find(t => t.name === 'create_entities');
+          const createEntities = tools.tools.find(t => t.name === 'memory__create_entities');
           expect(createEntities?.inputSchema).toBeDefined();
           expect(createEntities?.inputSchema.type).toBe('object');
           expect(createEntities?.inputSchema.properties).toHaveProperty('entities');
@@ -134,7 +134,7 @@ describe('MCP Server Integration Tests', () => {
             },
           ];
 
-          const result = await callTool('create_entities', { entities });
+          const result = await callTool('memory__create_entities', { entities });
           expect(result).toHaveLength(2);
           expect(result[0].name).toBe('Test User');
           expect(result[1].name).toBe('Test Project');
@@ -142,7 +142,7 @@ describe('MCP Server Integration Tests', () => {
 
         it('should delete entities', async () => {
           // Create entities first
-          await callTool('create_entities', {
+          await callTool('memory__create_entities', {
             entities: [{
               name: 'To Delete',
               entityType: 'Test',
@@ -151,7 +151,7 @@ describe('MCP Server Integration Tests', () => {
           });
 
           // Delete the entity
-          const deleteResult = await callTool('delete_entities', {
+          const deleteResult = await callTool('memory__delete_entities', {
             entityNames: ['To Delete'],
           });
 
@@ -159,7 +159,7 @@ describe('MCP Server Integration Tests', () => {
           expect(deleteResult).toBe('Entities deleted successfully');
 
           // Verify it's gone
-          const graph = await callTool('read_graph', {});
+          const graph = await callTool('memory__read_graph', {});
           expect(graph.entities).toHaveLength(0);
         });
       });
@@ -167,7 +167,7 @@ describe('MCP Server Integration Tests', () => {
       describe('Observation Operations', () => {
         beforeEach(async () => {
           // Create a test entity
-          await callTool('create_entities', {
+          await callTool('memory__create_entities', {
             entities: [{
               name: 'Observable Entity',
               entityType: 'Test',
@@ -177,7 +177,7 @@ describe('MCP Server Integration Tests', () => {
         });
 
         it('should add observations', async () => {
-          const result = await callTool('add_observations', {
+          const result = await callTool('memory__add_observations', {
             observations: [{
               entityName: 'Observable Entity',
               contents: ['New observation 1', 'New observation 2'],
@@ -190,7 +190,7 @@ describe('MCP Server Integration Tests', () => {
 
         it('should delete observations', async () => {
           // Add observations first
-          await callTool('add_observations', {
+          await callTool('memory__add_observations', {
             observations: [{
               entityName: 'Observable Entity',
               contents: ['To delete 1', 'To keep', 'To delete 2'],
@@ -198,7 +198,7 @@ describe('MCP Server Integration Tests', () => {
           });
 
           // Delete specific observations
-          const deleteResult = await callTool('delete_observations', {
+          const deleteResult = await callTool('memory__delete_observations', {
             deletions: [{
               entityName: 'Observable Entity',
               observations: ['To delete 1', 'To delete 2'],
@@ -209,7 +209,7 @@ describe('MCP Server Integration Tests', () => {
           expect(deleteResult).toBe('Observations deleted successfully');
 
           // Verify correct observations remain
-          const result = await callTool('open_nodes', {
+          const result = await callTool('memory__open_nodes', {
             names: ['Observable Entity'],
           });
           
@@ -224,7 +224,7 @@ describe('MCP Server Integration Tests', () => {
       describe('Relation Operations', () => {
         beforeEach(async () => {
           // Create entities for relations
-          await callTool('create_entities', {
+          await callTool('memory__create_entities', {
             entities: [
               {
                 name: 'Entity A',
@@ -241,7 +241,7 @@ describe('MCP Server Integration Tests', () => {
         });
 
         it('should create relations', async () => {
-          const result = await callTool('create_relations', {
+          const result = await callTool('memory__create_relations', {
             relations: [{
               from: 'Entity A',
               to: 'Entity B',
@@ -257,7 +257,7 @@ describe('MCP Server Integration Tests', () => {
 
         it('should delete relations', async () => {
           // Create relation first
-          await callTool('create_relations', {
+          await callTool('memory__create_relations', {
             relations: [{
               from: 'Entity A',
               to: 'Entity B',
@@ -266,7 +266,7 @@ describe('MCP Server Integration Tests', () => {
           });
 
           // Delete the relation
-          const deleteResult = await callTool('delete_relations', {
+          const deleteResult = await callTool('memory__delete_relations', {
             relations: [{
               from: 'Entity A',
               to: 'Entity B',
@@ -278,7 +278,7 @@ describe('MCP Server Integration Tests', () => {
           expect(deleteResult).toBe('Relations deleted successfully');
 
           // Verify it's gone
-          const graph = await callTool('read_graph', {});
+          const graph = await callTool('memory__read_graph', {});
           expect(graph.relations).toHaveLength(0);
         });
       });
@@ -286,7 +286,7 @@ describe('MCP Server Integration Tests', () => {
       describe('Query Operations', () => {
         beforeEach(async () => {
           // Create test data
-          await callTool('create_entities', {
+          await callTool('memory__create_entities', {
             entities: [
               {
                 name: 'Searchable Entity',
@@ -301,7 +301,7 @@ describe('MCP Server Integration Tests', () => {
             ],
           });
 
-          await callTool('create_relations', {
+          await callTool('memory__create_relations', {
             relations: [{
               from: 'Searchable Entity',
               to: 'Another Entity',
@@ -311,14 +311,14 @@ describe('MCP Server Integration Tests', () => {
         });
 
         it('should read entire graph', async () => {
-          const graph = await callTool('read_graph', {});
+          const graph = await callTool('memory__read_graph', {});
           
           expect(graph.entities).toHaveLength(2);
           expect(graph.relations).toHaveLength(1);
         });
 
         it('should search nodes by query', async () => {
-          const results = await callTool('search_nodes', {
+          const results = await callTool('memory__search_nodes', {
             query: 'KEYWORD',
           });
 
@@ -328,7 +328,7 @@ describe('MCP Server Integration Tests', () => {
         });
 
         it('should open specific nodes', async () => {
-          const result = await callTool('open_nodes', {
+          const result = await callTool('memory__open_nodes', {
             names: ['Searchable Entity', 'Another Entity'],
           });
 
@@ -342,7 +342,7 @@ describe('MCP Server Integration Tests', () => {
       describe('Statistics', () => {
         it('should return correct statistics', async () => {
           // Create test data
-          await callTool('create_entities', {
+          await callTool('memory__create_entities', {
             entities: [
               {
                 name: 'Stats Entity 1',
@@ -357,7 +357,7 @@ describe('MCP Server Integration Tests', () => {
             ],
           });
 
-          await callTool('create_relations', {
+          await callTool('memory__create_relations', {
             relations: [{
               from: 'Stats Entity 1',
               to: 'Stats Entity 2',
@@ -365,7 +365,7 @@ describe('MCP Server Integration Tests', () => {
             }],
           });
 
-          const stats = await callTool('get_stats', {});
+          const stats = await callTool('memory__get_stats', {});
           
           expect(stats.entityCount).toBe(2);
           expect(stats.relationCount).toBe(1);
@@ -387,7 +387,7 @@ describe('MCP Server Integration Tests', () => {
         it('should handle invalid arguments', async () => {
           // Try to create entities with invalid structure
           await expect(
-            callTool('create_entities', {
+            callTool('memory__create_entities', {
               // Missing required 'entities' field
               wrongField: [],
             })
@@ -398,7 +398,7 @@ describe('MCP Server Integration Tests', () => {
       describe('Complex Scenarios', () => {
         it('should handle a complete workflow', async () => {
           // 1. Create entities
-          await callTool('create_entities', {
+          await callTool('memory__create_entities', {
             entities: [
               {
                 name: 'Project Alpha',
@@ -419,7 +419,7 @@ describe('MCP Server Integration Tests', () => {
           });
 
           // 2. Create relations
-          await callTool('create_relations', {
+          await callTool('memory__create_relations', {
             relations: [
               {
                 from: 'John Doe',
@@ -435,7 +435,7 @@ describe('MCP Server Integration Tests', () => {
           });
 
           // 3. Add more observations
-          await callTool('add_observations', {
+          await callTool('memory__add_observations', {
             observations: [{
               entityName: 'Project Alpha',
               contents: ['Deployed to production', 'Serves 1000 users'],
@@ -443,19 +443,19 @@ describe('MCP Server Integration Tests', () => {
           });
 
           // 4. Search for AI-related nodes
-          const searchResult = await callTool('search_nodes', {
+          const searchResult = await callTool('memory__search_nodes', {
             query: 'AI',
           });
           expect(searchResult.entities).toHaveLength(3); // Project Alpha, John Doe (AI expert), and AI Module
 
           // 5. Get statistics
-          const stats = await callTool('get_stats', {});
+          const stats = await callTool('memory__get_stats', {});
           expect(stats.entityCount).toBe(3);
           expect(stats.relationCount).toBe(2);
           expect(stats.observationCount).toBe(8);
 
           // 6. Read full graph
-          const graph = await callTool('read_graph', {});
+          const graph = await callTool('memory__read_graph', {});
           expect(graph.entities).toHaveLength(3);
           expect(graph.relations).toHaveLength(2);
         });

--- a/test/unit/server-factory-schemas.test.ts
+++ b/test/unit/server-factory-schemas.test.ts
@@ -8,7 +8,8 @@ import {
   DeleteRelationsSchema,
   ReadGraphSchema,
   SearchNodesSchema,
-  OpenNodesSchema
+  OpenNodesSchema,
+  GetStatsSchema
 } from '../../server-factory-schemas.js';
 
 describe('server-factory-schemas', () => {
@@ -149,6 +150,17 @@ describe('server-factory-schemas', () => {
 
     it('should not have required fields', () => {
       expect(ReadGraphSchema.required).toBeUndefined();
+    });
+  });
+
+  describe('GetStatsSchema', () => {
+    it('should have correct structure', () => {
+      expect(GetStatsSchema.type).toBe('object');
+      expect(GetStatsSchema.properties).toEqual({});
+    });
+
+    it('should not have required fields', () => {
+      expect((GetStatsSchema as { required?: unknown }).required).toBeUndefined();
     });
   });
 

--- a/test/unit/server-factory.test.ts
+++ b/test/unit/server-factory.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { createServerFromFactory } from '../../server-factory.js';
 import * as storageFactory from '../../storage/factory.js';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { VERSION } from '../../version.js';
 
 // Mock the storage factory module
 vi.mock('../../storage/factory.js', () => ({
@@ -76,7 +77,7 @@ describe('server-factory', () => {
       expect(Server).toHaveBeenCalledWith(
         {
           name: 'memory',
-          version: '0.6.3'
+          version: VERSION
         },
         {
           capabilities: {
@@ -127,7 +128,7 @@ describe('server-factory', () => {
       
       const response = await listToolsHandler();
       
-      expect(response.tools).toHaveLength(9);
+      expect(response.tools).toHaveLength(10);
       expect(response.tools[0].name).toBe('memory__create_entities');
       expect(response.tools[1].name).toBe('memory__create_relations');
       expect(response.tools[2].name).toBe('memory__add_observations');
@@ -137,6 +138,7 @@ describe('server-factory', () => {
       expect(response.tools[6].name).toBe('memory__read_graph');
       expect(response.tools[7].name).toBe('memory__search_nodes');
       expect(response.tools[8].name).toBe('memory__open_nodes');
+      expect(response.tools[9].name).toBe('memory__get_stats');
     });
 
     it('should include correct descriptions for tools', async () => {
@@ -355,6 +357,29 @@ describe('server-factory', () => {
       const result = JSON.parse(response.content[0].text);
       expect(result).toHaveProperty('entities');
       expect(result).toHaveProperty('relations');
+    });
+
+    it('should handle memory__get_stats', async () => {
+      mockStorage.getStats.mockResolvedValue({
+        entityCount: 2,
+        relationCount: 1,
+        observationCount: 3
+      });
+
+      const request = {
+        params: {
+          name: 'memory__get_stats',
+          arguments: {}
+        }
+      };
+
+      const response = await callToolHandler(request);
+
+      expect(response.content).toHaveLength(1);
+      const result = JSON.parse(response.content[0].text);
+      expect(result.entityCount).toBe(2);
+      expect(result.relationCount).toBe(1);
+      expect(result.observationCount).toBe(3);
     });
 
     it('should throw error for unknown tool', async () => {

--- a/tools.ts
+++ b/tools.ts
@@ -1,0 +1,133 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { KnowledgeGraphManager } from './knowledge-graph-manager.js';
+import { Entity, Relation } from './types.js';
+import {
+  CreateEntitiesSchema,
+  CreateRelationsSchema,
+  AddObservationsSchema,
+  DeleteEntitiesSchema,
+  DeleteObservationsSchema,
+  DeleteRelationsSchema,
+  ReadGraphSchema,
+  SearchNodesSchema,
+  OpenNodesSchema,
+  GetStatsSchema,
+} from './server-factory-schemas.js';
+
+/**
+ * Single source of truth for the memory tools, shared by every transport
+ * (stdio in index.ts and HTTP/SSE in server-factory.ts) so the two can never
+ * drift in tool names, schemas, descriptions, or behaviour.
+ *
+ * Tool names are prefixed with `memory__` to namespace them on clients that
+ * connect to multiple MCP servers.
+ */
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: object;
+}
+
+export const memoryTools: ToolDefinition[] = [
+  {
+    name: 'memory__create_entities',
+    description: 'Create multiple new entities in the knowledge graph',
+    inputSchema: CreateEntitiesSchema,
+  },
+  {
+    name: 'memory__create_relations',
+    description: 'Create multiple new relations between entities in the knowledge graph. Relations should be in active voice',
+    inputSchema: CreateRelationsSchema,
+  },
+  {
+    name: 'memory__add_observations',
+    description: 'Add new observations to existing entities in the knowledge graph',
+    inputSchema: AddObservationsSchema,
+  },
+  {
+    name: 'memory__delete_entities',
+    description: 'Delete multiple entities and their associated relations from the knowledge graph',
+    inputSchema: DeleteEntitiesSchema,
+  },
+  {
+    name: 'memory__delete_observations',
+    description: 'Delete specific observations from entities in the knowledge graph',
+    inputSchema: DeleteObservationsSchema,
+  },
+  {
+    name: 'memory__delete_relations',
+    description: 'Delete multiple relations from the knowledge graph',
+    inputSchema: DeleteRelationsSchema,
+  },
+  {
+    name: 'memory__read_graph',
+    description: 'Read the entire knowledge graph',
+    inputSchema: ReadGraphSchema,
+  },
+  {
+    name: 'memory__search_nodes',
+    description: 'Search for nodes in the knowledge graph based on a query',
+    inputSchema: SearchNodesSchema,
+  },
+  {
+    name: 'memory__open_nodes',
+    description: 'Open specific nodes in the knowledge graph by their names',
+    inputSchema: OpenNodesSchema,
+  },
+  {
+    name: 'memory__get_stats',
+    description: 'Get statistics about the knowledge graph storage',
+    inputSchema: GetStatsSchema,
+  },
+];
+
+function toText(value: unknown): CallToolResult {
+  const text = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+  return { content: [{ type: 'text', text }] };
+}
+
+/**
+ * Execute a memory tool by name. Shared by all transports so behaviour is
+ * identical regardless of how the request arrived.
+ */
+export async function callMemoryTool(
+  manager: KnowledgeGraphManager,
+  name: string,
+  args: Record<string, unknown> | undefined
+): Promise<CallToolResult> {
+  // read_graph and get_stats take no arguments.
+  if (name === 'memory__read_graph') {
+    return toText(await manager.readGraph());
+  }
+  if (name === 'memory__get_stats') {
+    return toText(await manager.getStats());
+  }
+
+  if (!args) {
+    throw new Error(`No arguments provided for tool: ${name}`);
+  }
+
+  switch (name) {
+    case 'memory__create_entities':
+      return toText(await manager.createEntities(args.entities as Entity[]));
+    case 'memory__create_relations':
+      return toText(await manager.createRelations(args.relations as Relation[]));
+    case 'memory__add_observations':
+      return toText(await manager.addObservations(args.observations as { entityName: string; contents: string[] }[]));
+    case 'memory__delete_entities':
+      await manager.deleteEntities(args.entityNames as string[]);
+      return toText('Entities deleted successfully');
+    case 'memory__delete_observations':
+      await manager.deleteObservations(args.deletions as { entityName: string; observations: string[] }[]);
+      return toText('Observations deleted successfully');
+    case 'memory__delete_relations':
+      await manager.deleteRelations(args.relations as Relation[]);
+      return toText('Relations deleted successfully');
+    case 'memory__search_nodes':
+      return toText(await manager.searchNodes(args.query as string));
+    case 'memory__open_nodes':
+      return toText(await manager.openNodes(args.names as string[]));
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}

--- a/version.ts
+++ b/version.ts
@@ -1,0 +1,28 @@
+import { fileURLToPath } from 'url';
+import path from 'path';
+import { readFileSync } from 'fs';
+
+/**
+ * Single source of truth for the server version reported to MCP clients.
+ * Read from package.json so it can never drift from the published version.
+ *
+ * This file lives at the repo root in source (run directly by vitest) but is
+ * compiled to dist/ at build time, so package.json is either in the same
+ * directory (source) or one level up (dist/). Try both.
+ */
+function readVersion(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  for (const candidate of ['package.json', '../package.json']) {
+    try {
+      const pkg = JSON.parse(readFileSync(path.join(here, candidate), 'utf-8')) as { version?: string };
+      if (typeof pkg.version === 'string') {
+        return pkg.version;
+      }
+    } catch {
+      // try the next candidate location
+    }
+  }
+  return '0.0.0';
+}
+
+export const VERSION: string = readVersion();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
         'server-factory.ts',
         'server-factory-schemas.ts',
         'health-server.ts',
+        'tools.ts',
         'types.ts'
       ],
       thresholds: {


### PR DESCRIPTION
## Description
Part **4/6** of the v2.0.0 remediation stack. **This is the breaking change that motivates the major version bump.**

The stdio and HTTP/SSE transports each defined the tool list and dispatch inline, and they had drifted: stdio exposed unprefixed names plus `get_stats`; HTTP exposed `memory__*` names without `get_stats`. Both hard-coded the reported version as `0.6.3` while the package was `1.0.3`.

- New shared `tools.ts` (tool definitions + dispatch) used by **both** transports
- **BREAKING:** stdio tool names are now `memory__`-prefixed to match HTTP (chosen canonical naming); both transports now expose the same **10** tools incl. `memory__get_stats`
- Version is read from `package.json` via a new `version.ts` (single source of truth)
- `tools.ts` added to coverage (100%)

## Server Details
- Server: memory
- Changes to: tools (names + registration), reported version

## Motivation and Context
Two transports exposing different tool names from duplicated definitions is a correctness hazard; the reported version had drifted from the package.

## How Has This Been Tested?
Integration test renamed to `memory__*` and passes against the real spawned server; factory/schema unit tests updated; live probe confirms stdio reports `memory__*` tools + version. Full suite + lint/typecheck green.

## Breaking Changes
**Yes.** Tool names on the **stdio** transport change from `create_entities` → `memory__create_entities`, etc. MCP clients that discover tools dynamically are unaffected; any client/script/allow-list that hard-codes the old stdio names must update. Documented in `CHANGELOG.md`.

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] New and existing tests pass locally
- [x] My changes follows MCP security best practices
- [x] I have documented all environment variables and configuration options

## Additional context
Stacked on #35. Warrants the v2.0.0 major bump (applied at release cut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)