### PR TITLE
fix: graceful shutdown and shared storage for HTTP sessions (5/6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can no longer corrupt the JSONL file; parse errors now report the offending line
 - Resolved unresolved git merge-conflict markers shipped in `README.md`
 - Build now cleans `dist/` first, so stale/test artifacts are no longer published
+- **Graceful shutdown** - the server now handles SIGINT/SIGTERM, closing the storage
+  backend (whose `close()` was previously never called) and the health/HTTP servers
+- **HTTP session resource leak** - all HTTP/SSE sessions now share one storage backend
+  instead of each opening (and never closing) its own backend, which for SQLite leaked
+  a database connection per session
+- The SSE `/events` endpoint now rejects a second concurrent stream for a session
+  instead of connecting the server to a second transport and leaking the first stream
 
 ### Performance
 - Eliminated the SQLite N+1 observation query in `loadGraph`, `searchEntities`, and

--- a/http-server.ts
+++ b/http-server.ts
@@ -2,10 +2,14 @@
 
 import express from 'express';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { createServerFromFactory } from './server-factory.js';
+import { createMemoryServer } from './server-factory.js';
+import { createStorageFromEnv } from './storage/factory.js';
+import { KnowledgeGraphManager } from './knowledge-graph-manager.js';
+import type { IStorageBackend } from './storage/interface.js';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { v4 as uuidv4 } from 'uuid';
+import type { Server as HttpServer } from 'http';
 
 interface SessionData {
   id: string;
@@ -21,50 +25,47 @@ app.use(express.json());
 const sessions = new Map<string, SessionData>();
 const SESSION_TIMEOUT = 30 * 60 * 1000; // 30 minutes
 
-// Clean up inactive sessions
-setInterval(() => {
-  const now = Date.now();
-  for (const [id, session] of sessions.entries()) {
-    if (now - session.lastActivity > SESSION_TIMEOUT) {
-      console.log(`Cleaning up inactive session: ${id}`);
-      sessions.delete(id);
-    }
-  }
-}, 60 * 1000); // Check every minute
+// One storage backend / manager is shared across all sessions. Previously each
+// session created its own backend (and, for SQLite, its own DB connection) that
+// was never closed, leaking file descriptors as sessions came and went.
+let sharedStorage: IStorageBackend | undefined;
+let sharedManager: KnowledgeGraphManager | undefined;
+let httpServer: HttpServer | undefined;
+let cleanupInterval: ReturnType<typeof setInterval> | undefined;
 
 class HTTPTransport implements Transport {
   onclose?: () => void;
   onerror?: (error: Error) => void;
   onmessage?: (message: JSONRPCMessage) => void;
   private res?: express.Response;
-  
+
   async send(message: JSONRPCMessage): Promise<void> {
     if (this.res) {
       this.res.json(message);
       this.res = undefined;
     }
   }
-  
+
   setResponse(res: express.Response) {
     this.res = res;
   }
-  
+
   handleMessage(message: JSONRPCMessage) {
     if (this.onmessage) {
       this.onmessage(message);
     }
   }
-  
+
   async close() {
     if (this.onclose) {
       this.onclose();
     }
   }
-  
+
   async start() {
     // HTTP transport doesn't need initialization
   }
-  
+
   error(error: Error) {
     if (this.onerror) {
       this.onerror(error);
@@ -77,36 +78,37 @@ class SSETransport implements Transport {
   onerror?: (error: Error) => void;
   onmessage?: (message: JSONRPCMessage) => void;
   private res?: express.Response;
-  
+
   async send(message: JSONRPCMessage): Promise<void> {
     if (this.res) {
       this.res.write(`data: ${JSON.stringify(message)}\n\n`);
     }
   }
-  
+
   setResponse(res: express.Response) {
     this.res = res;
   }
-  
+
   handleMessage(message: JSONRPCMessage) {
     if (this.onmessage) {
       this.onmessage(message);
     }
   }
-  
+
   async close() {
     if (this.res) {
       this.res.end();
+      this.res = undefined;
     }
     if (this.onclose) {
       this.onclose();
     }
   }
-  
+
   async start() {
     // SSE transport doesn't need initialization
   }
-  
+
   error(error: Error) {
     if (this.onerror) {
       this.onerror(error);
@@ -115,20 +117,23 @@ class SSETransport implements Transport {
 }
 
 async function createSession(): Promise<SessionData> {
+  if (!sharedManager) {
+    throw new Error('HTTP server not initialized');
+  }
   const id = uuidv4();
-  const server = await createServerFromFactory();
+  const server = createMemoryServer(sharedManager);
   const transport = new HTTPTransport();
-  
+
   const session: SessionData = {
     id,
     server,
     transport,
     lastActivity: Date.now(),
   };
-  
+
   await server.connect(transport);
   sessions.set(id, session);
-  
+
   return session;
 }
 
@@ -145,15 +150,15 @@ app.post('/session', async (_req, res) => {
 app.post('/session/:sessionId/message', async (req, res) => {
   const { sessionId } = req.params;
   const message = req.body as JSONRPCMessage;
-  
+
   const session = sessions.get(sessionId);
   if (!session) {
     res.status(404).json({ error: 'Session not found' });
     return;
   }
-  
+
   session.lastActivity = Date.now();
-  
+
   if (session.transport instanceof HTTPTransport) {
     session.transport.setResponse(res);
     session.transport.handleMessage(message);
@@ -169,46 +174,53 @@ app.post('/session/:sessionId/message', async (req, res) => {
 
 app.get('/session/:sessionId/events', async (req, res) => {
   const { sessionId } = req.params;
-  
+
   const session = sessions.get(sessionId);
   if (!session) {
     res.status(404).json({ error: 'Session not found' });
     return;
   }
-  
+
+  // Only one SSE stream per session. A second /events call would connect the
+  // server to a second transport and leak the first stream + its keep-alive.
+  if (session.isSSE) {
+    res.status(409).json({ error: 'Session already has an active SSE stream' });
+    return;
+  }
+
   // Mark session as SSE mode
   session.isSSE = true;
   session.lastActivity = Date.now();
-  
+
   // Create SSE transport and connect to server
   const sseTransport = new SSETransport();
   session.transport = sseTransport;
-  
+
   // Connect the SSE transport to the server
   await session.server.connect(sseTransport);
-  
+
   res.writeHead(200, {
     'Content-Type': 'text/event-stream',
     'Cache-Control': 'no-cache',
     'Connection': 'keep-alive',
     'Access-Control-Allow-Origin': '*',
   });
-  
+
   sseTransport.setResponse(res);
-  
+
   // Send initial connection event
   res.write(':connected\n\n');
-  
+
   // Keep connection alive
   const keepAlive = setInterval(() => {
     res.write(':keep-alive\n\n');
   }, 30000);
-  
+
   req.on('close', () => {
     clearInterval(keepAlive);
-    sseTransport.close();
-    // Don't delete the session here - let the explicit DELETE endpoint handle it
-    // Just mark it as no longer in SSE mode
+    void sseTransport.close();
+    // Don't delete the session here - let the explicit DELETE endpoint handle it.
+    // Just mark it as no longer in SSE mode so a new stream can be attached.
     if (session) {
       session.isSSE = false;
     }
@@ -217,15 +229,15 @@ app.get('/session/:sessionId/events', async (req, res) => {
 
 app.delete('/session/:sessionId', (req, res) => {
   const { sessionId } = req.params;
-  
+
   const session = sessions.get(sessionId);
   if (!session) {
     console.error(`Session ${sessionId} not found for deletion. Available sessions:`, Array.from(sessions.keys()));
     res.status(404).json({ error: 'Session not found' });
     return;
   }
-  
-  session.transport.close();
+
+  void session.transport.close();
   sessions.delete(sessionId);
   res.json({ message: 'Session closed' });
 });
@@ -240,9 +252,70 @@ app.get('/health', (_req, res) => {
 
 const PORT = process.env.HTTP_PORT || 3000;
 
-export default function runHttpServer() {
-  app.listen(PORT, () => {
-    console.log(`MCP Memory HTTP Server listening on port ${PORT}`);
-    console.log(`Health check: http://localhost:${PORT}/health`);
+async function closeAll(): Promise<void> {
+  if (cleanupInterval) {
+    clearInterval(cleanupInterval);
+    cleanupInterval = undefined;
+  }
+
+  // Close every live session transport so no SSE stream is left dangling.
+  for (const session of sessions.values()) {
+    try {
+      await session.transport.close();
+    } catch {
+      // ignore individual transport close errors
+    }
+  }
+  sessions.clear();
+
+  await new Promise<void>((resolve) => {
+    if (httpServer) {
+      httpServer.close(() => resolve());
+      // Force-close lingering keep-alive/SSE sockets so close() can complete
+      // promptly instead of waiting on idle connections (Node >= 18.2).
+      (httpServer as { closeAllConnections?: () => void }).closeAllConnections?.();
+    } else {
+      resolve();
+    }
   });
+  httpServer = undefined;
+
+  if (sharedStorage) {
+    try {
+      await sharedStorage.close();
+    } catch (error) {
+      console.error('Error closing storage:', error);
+    }
+    sharedStorage = undefined;
+    sharedManager = undefined;
+  }
+}
+
+export default async function runHttpServer(): Promise<{ close: () => Promise<void> }> {
+  // Initialise the single shared storage backend up front.
+  sharedStorage = createStorageFromEnv();
+  await sharedStorage.initialize();
+  sharedManager = new KnowledgeGraphManager(sharedStorage);
+
+  // Evict inactive sessions and release their transports.
+  cleanupInterval = setInterval(() => {
+    const now = Date.now();
+    for (const [id, session] of sessions.entries()) {
+      if (now - session.lastActivity > SESSION_TIMEOUT) {
+        console.log(`Cleaning up inactive session: ${id}`);
+        void session.transport.close();
+        sessions.delete(id);
+      }
+    }
+  }, 60 * 1000); // Check every minute
+
+  await new Promise<void>((resolve) => {
+    httpServer = app.listen(PORT, () => {
+      console.log(`MCP Memory HTTP Server listening on port ${PORT}`);
+      console.log(`Health check: http://localhost:${PORT}/health`);
+      resolve();
+    });
+  });
+
+  return { close: closeAll };
 }

--- a/index.ts
+++ b/index.ts
@@ -15,10 +15,39 @@ import { VERSION } from './version.js';
 // Initialize storage backend and knowledge graph manager
 let knowledgeGraphManager: KnowledgeGraphManager;
 
+// Cleanup callbacks run (in reverse order) on graceful shutdown.
+const cleanups: Array<() => Promise<void> | void> = [];
+let shuttingDown = false;
+
+async function shutdown(reason: string, code = 0): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.error(`Shutting down (${reason})...`);
+  for (const cleanup of [...cleanups].reverse()) {
+    try {
+      await cleanup();
+    } catch (err) {
+      console.error('Error during shutdown cleanup:', err);
+    }
+  }
+  process.exit(code);
+}
+
+process.on('SIGINT', () => { void shutdown('SIGINT'); });
+process.on('SIGTERM', () => { void shutdown('SIGTERM'); });
+process.on('uncaughtException', (err) => {
+  console.error('Uncaught exception:', err);
+  void shutdown('uncaughtException', 1);
+});
+process.on('unhandledRejection', (reason) => {
+  console.error('Unhandled promise rejection:', reason);
+});
+
 async function initializeStorage() {
   const storage = createStorageFromEnv();
   await storage.initialize();
   knowledgeGraphManager = new KnowledgeGraphManager(storage);
+  cleanups.push(() => storage.close());
 
   // Log storage type for debugging
   const storageType = process.env.STORAGE_TYPE || 'json';
@@ -55,7 +84,8 @@ async function main() {
   if (transportType === 'http' || transportType === 'sse') {
     // Use dynamic import for HTTP server
     const { default: runHttpServer } = await import('./http-server.js');
-    runHttpServer();
+    const handle = await runHttpServer();
+    cleanups.push(() => handle.close());
     return;
   }
 
@@ -65,7 +95,8 @@ async function main() {
   // Start health check server if port is specified
   const healthPort = parseInt(process.env.PORT || '6970', 10);
   if (!isNaN(healthPort) && healthPort > 0) {
-    startHealthServer(healthPort, knowledgeGraphManager);
+    const healthServer = startHealthServer(healthPort, knowledgeGraphManager);
+    cleanups.push(() => new Promise<void>((resolve) => healthServer.close(() => resolve())));
   }
 
   const transport = new StdioServerTransport();

--- a/server-factory.ts
+++ b/server-factory.ts
@@ -9,11 +9,13 @@ import {
 import { memoryTools, callMemoryTool } from './tools.js';
 import { VERSION } from './version.js';
 
-export async function createServerFromFactory(): Promise<Server> {
-  const storage: IStorageBackend = createStorageFromEnv();
-  await storage.initialize();
-  const manager = new KnowledgeGraphManager(storage);
-
+/**
+ * Build an MCP server bound to an existing KnowledgeGraphManager. Tool
+ * definitions and dispatch are shared with the stdio transport via ./tools.ts
+ * so the two transports can never drift. Callers that handle many sessions
+ * should share one manager (and therefore one storage backend) across them.
+ */
+export function createMemoryServer(manager: KnowledgeGraphManager): Server {
   const server = new Server(
     {
       name: 'memory',
@@ -26,8 +28,6 @@ export async function createServerFromFactory(): Promise<Server> {
     }
   );
 
-  // Tool definitions and dispatch are shared with the stdio transport via
-  // ./tools.ts so the two transports can never drift.
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     return { tools: memoryTools };
   });
@@ -38,4 +38,16 @@ export async function createServerFromFactory(): Promise<Server> {
   });
 
   return server;
+}
+
+/**
+ * Convenience factory that creates a storage backend from the environment and
+ * returns a server bound to it. Each call creates its own backend, so prefer
+ * createMemoryServer with a shared manager when serving multiple sessions.
+ */
+export async function createServerFromFactory(): Promise<Server> {
+  const storage: IStorageBackend = createStorageFromEnv();
+  await storage.initialize();
+  const manager = new KnowledgeGraphManager(storage);
+  return createMemoryServer(manager);
 }


### PR DESCRIPTION
## Description
Part **5/6** of the v2.0.0 remediation stack.

- **SIGINT/SIGTERM graceful shutdown** that closes the storage backend (its `close()` was previously never called) and the health/HTTP servers; logs uncaught exceptions / unhandled rejections
- HTTP/SSE sessions now **share one storage backend** created at startup, instead of each session opening (and never closing) its own — a per-session fd/connection leak for SQLite. `server-factory` now exposes `createMemoryServer(manager)`
- The SSE `/events` endpoint rejects a **second concurrent stream** (409) instead of connecting the server to a second transport and leaking the first

## Server Details
- Server: memory
- Changes to: process lifecycle, HTTP/SSE transport

## Motivation and Context
Storage was never closed on shutdown and every HTTP session leaked a backend/connection.

## How Has This Been Tested?
Full unit + e2e suite (real spawned HTTP/SSE server) green; live SIGTERM test confirms clean shutdown. Lint/typecheck green.

## Breaking Changes
None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling

## Additional context
Stacked on #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)