### PR TITLE
feat: opt-in hardening for the HTTP/SSE transport (6/6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dead `src/memory/**` tree (excluded from the build, never imported) and stray root
   files (`test-benchmark.ts`, `test-sqlite.ts`, `test-coverage-analysis.md`)
 
+### Security
+- HTTP transport gained opt-in hardening, all disabled by default to preserve the
+  current trusted/localhost behaviour: bearer-token auth via `HTTP_AUTH_TOKEN`,
+  configurable `HTTP_CORS_ORIGIN`, a `HTTP_BODY_LIMIT` request-size cap, `HTTP_PORT`
+  range validation, and surfaced `listen` errors (e.g. `EADDRINUSE`)
+
 ## [1.0.3] - 2026-06-13
 
 ### 📊 Benchmarking & Tooling

--- a/HTTP-TRANSPORT.md
+++ b/HTTP-TRANSPORT.md
@@ -30,6 +30,17 @@ By default, the HTTP server runs on port 3000. You can change this with the `HTT
 HTTP_PORT=8080 TRANSPORT_TYPE=http npm start
 ```
 
+### Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HTTP_PORT` | `3000` | Port for the HTTP/SSE server (must be 1-65535) |
+| `HTTP_BODY_LIMIT` | `1mb` | Maximum accepted JSON request body size |
+| `HTTP_AUTH_TOKEN` | _(unset)_ | If set, all `/session` endpoints require `Authorization: Bearer <token>`. Disabled by default for trusted/localhost use; `/health` is always open |
+| `HTTP_CORS_ORIGIN` | `*` | `Access-Control-Allow-Origin` value sent on the SSE stream; set to a specific origin to restrict cross-origin access |
+
+> **Security note:** This transport is intended for trusted/localhost deployments. If you expose it beyond localhost, set `HTTP_AUTH_TOKEN`, restrict `HTTP_CORS_ORIGIN`, and place it behind a TLS-terminating reverse proxy.
+
 ## API Reference
 
 ### Create Session

--- a/http-server.ts
+++ b/http-server.ts
@@ -20,7 +20,31 @@ interface SessionData {
 }
 
 const app = express();
-app.use(express.json());
+
+// Cap request body size to avoid unbounded-payload memory pressure. Configurable
+// because some callers legitimately send large batches.
+app.use(express.json({ limit: process.env.HTTP_BODY_LIMIT || '1mb' }));
+
+// Optional bearer-token auth. Disabled by default (suitable for the trusted/
+// localhost deployments this transport targets); set HTTP_AUTH_TOKEN to require
+// `Authorization: Bearer <token>` on all /session endpoints.
+const AUTH_TOKEN = process.env.HTTP_AUTH_TOKEN;
+const requireAuth: express.RequestHandler = (req, res, next) => {
+  if (!AUTH_TOKEN) {
+    next();
+    return;
+  }
+  if (req.headers.authorization === `Bearer ${AUTH_TOKEN}`) {
+    next();
+    return;
+  }
+  res.status(401).json({ error: 'Unauthorized' });
+};
+app.use('/session', requireAuth);
+
+// Origin returned for the SSE stream. Defaults to '*' for backward compatibility;
+// set HTTP_CORS_ORIGIN to lock cross-origin access down to a specific origin.
+const CORS_ORIGIN = process.env.HTTP_CORS_ORIGIN || '*';
 
 const sessions = new Map<string, SessionData>();
 const SESSION_TIMEOUT = 30 * 60 * 1000; // 30 minutes
@@ -203,7 +227,7 @@ app.get('/session/:sessionId/events', async (req, res) => {
     'Content-Type': 'text/event-stream',
     'Cache-Control': 'no-cache',
     'Connection': 'keep-alive',
-    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Origin': CORS_ORIGIN,
   });
 
   sseTransport.setResponse(res);
@@ -250,7 +274,18 @@ app.get('/health', (_req, res) => {
   });
 });
 
-const PORT = process.env.HTTP_PORT || 3000;
+function parsePort(value: string | undefined, fallback: number): number {
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid HTTP_PORT "${value}": must be an integer between 1 and 65535`);
+  }
+  return port;
+}
+
+const PORT = parsePort(process.env.HTTP_PORT, 3000);
 
 async function closeAll(): Promise<void> {
   if (cleanupInterval) {
@@ -309,12 +344,15 @@ export default async function runHttpServer(): Promise<{ close: () => Promise<vo
     }
   }, 60 * 1000); // Check every minute
 
-  await new Promise<void>((resolve) => {
-    httpServer = app.listen(PORT, () => {
+  await new Promise<void>((resolve, reject) => {
+    const server = app.listen(PORT, () => {
       console.log(`MCP Memory HTTP Server listening on port ${PORT}`);
       console.log(`Health check: http://localhost:${PORT}/health`);
       resolve();
     });
+    // Surface listen failures (e.g. EADDRINUSE) instead of crashing silently.
+    server.on('error', (err) => reject(err));
+    httpServer = server;
   });
 
   return { close: closeAll };

--- a/index.ts
+++ b/index.ts
@@ -94,7 +94,7 @@ async function main() {
 
   // Start health check server if port is specified
   const healthPort = parseInt(process.env.PORT || '6970', 10);
-  if (!isNaN(healthPort) && healthPort > 0) {
+  if (!isNaN(healthPort) && healthPort > 0 && healthPort <= 65535) {
     const healthServer = startHealthServer(healthPort, knowledgeGraphManager);
     cleanups.push(() => new Promise<void>((resolve) => healthServer.close(() => resolve())));
   }


### PR DESCRIPTION
## Description
Part **6/6** of the v2.0.0 remediation stack. All additions are **disabled by default** so trusted/localhost deployments are unaffected.

- `HTTP_AUTH_TOKEN`: when set, `/session` endpoints require `Authorization: Bearer <token>` (`/health` stays open)
- `HTTP_CORS_ORIGIN`: configurable `Access-Control-Allow-Origin` for the SSE stream (default `*`)
- `HTTP_BODY_LIMIT`: JSON request-body cap (default `1mb`)
- `HTTP_PORT` range-validated (1–65535); `app.listen` errors (e.g. `EADDRINUSE`) surfaced instead of crashing silently
- Documented the new variables in `HTTP-TRANSPORT.md`

## Server Details
- Server: memory
- Changes to: HTTP/SSE transport configuration

## Motivation and Context
The HTTP transport had no auth, wildcard CORS, no body cap, and unvalidated ports. Deployment is localhost/trusted, so these are opt-in.

## How Has This Been Tested?
e2e suite green with defaults (auth off); live test confirms `HTTP_AUTH_TOKEN` gates `/session` (401/200) while `/health` stays open. Lint/typecheck green.

## Breaking Changes
None (defaults preserve current behavior).

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist
- [x] New and existing tests pass locally
- [x] My changes follows MCP security best practices
- [x] I have documented all environment variables and configuration options

## Additional context
Top of the stack, based on #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)